### PR TITLE
Fix error when image is inside two spans

### DIFF
--- a/src/elements/images.ts
+++ b/src/elements/images.ts
@@ -195,7 +195,7 @@ export const imageRules = [
 	
 	// Handle span elements containing images with captions
 	{
-		selector: 'span:has(img)',
+		selector: 'span:has(> img)',
 		element: 'span',
 		transform: (el: Element, doc: Document): Element => {
 			try {


### PR DESCRIPTION
Previously when I tried to parse a page with this fragment:

```
<span aria-owns="rmiz-modal-081871f9cc7f" data-rmiz=""><span data-rmiz-content="not-found" style="visibility: visible;"><img height="200" src="https://mintlify.s3.us-west-1.amazonaws.com/agno/images/debugging.png" style="border-radius: 8px;"></span></span>
```

I would get this error:

```
Error processing span with image: ReferenceError: Node is not defined
    at processNode (/home/mike/src/defuddle/src/elements/images.ts:656:25)
    at extractUniqueCaptionContent (/home/mike/src/defuddle/src/elements/images.ts:675:3)
    at createFigureWithCaption (/home/mike/src/defuddle/src/elements/images.ts:303:31)
    at Object.transform (/home/mike/src/defuddle/src/elements/images.ts:219:21)
    at <anonymous> (/home/mike/src/defuddle/src/standardize.ts:653:30)
    at Proxy.forEach (<anonymous>)
    at <anonymous> (/home/mike/src/defuddle/src/standardize.ts:650:12)
    at Array.forEach (<anonymous>)
    at standardizeElements (/home/mike/src/defuddle/src/standardize.ts:648:32)
    at standardizeContent (/home/mike/src/defuddle/src/standardize.ts:157:2)
```

Now we check only for spans with directly nested img tags.